### PR TITLE
Dinamik kullanıcı profillerini ve profil düzenlemeyi ekle

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -33,6 +33,7 @@ mongoose.connect(process.env.MONGO_URI)
     app.use('/api/auth', authRoutes);
     app.use('/api/mekanlar', mekanRoutes);
     app.use('/api/yorumlar', yorumRoutes);
+    app.use('/api/users', require('./routes/userRoutes')); 
 
     app.get('/', (req, res) => {
       res.send('Rize Kültür Projesi API Çalışıyor!');

--- a/api/routes/userRoutes.js
+++ b/api/routes/userRoutes.js
@@ -1,0 +1,37 @@
+// api/routes/userRoutes.js
+
+const express = require('express');
+const router = express.Router();
+const Kullanici = require('../models/Kullanici');
+const Yorum = require('../models/Yorum');
+
+// @route   GET api/users/:userId
+// @desc    ID ile tek bir kullanıcının halka açık profil bilgilerini getirir
+// @access  Public
+router.get('/:userId', async (req, res) => {
+    try {
+        // 1. Sadece halka açık olması gereken kullanıcı bilgilerini seçerek al
+        const kullanici = await Kullanici.findById(req.params.userId).select('kullaniciAdi profilFotoUrl');
+
+        if (!kullanici) {
+            return res.status(404).json({ msg: 'Kullanıcı bulunamadı' });
+        }
+
+        // 2. Bu kullanıcının yaptığı tüm yorumları al
+        const yorumlar = await Yorum.find({ yazar: req.params.userId })
+            .populate('mekan', 'isim fotograflar') // Yorumun hangi mekana yapıldığını göster
+            .sort({ yorumTarihi: -1 });
+
+        // 3. Kullanıcı bilgileri ve yorumlarını birleştirip gönder
+        res.json({
+            kullanici: kullanici,
+            yorumlar: yorumlar
+        });
+
+    } catch (err) {
+        console.error(err.message);
+        res.status(500).json({ msg: 'Sunucu Hatası' });
+    }
+});
+
+module.exports = router;

--- a/mobil_flutter/lib/data/models/user_model.dart
+++ b/mobil_flutter/lib/data/models/user_model.dart
@@ -1,9 +1,12 @@
+import 'package:mobil_flutter/data/models/yorum_model.dart';
+
 class UserModel {
   final String id;
   final String kullaniciAdi;
   final String email;
   final String? profilFotoUrl; // YENİ: Null olabilir
   final List<String> favoriMekanlar; // FAVORİ LİSTESİ ALANI
+    final List<YorumModel> yorumlar; // Bu alanı ekle
 
   UserModel({
     required this.id,
@@ -11,6 +14,7 @@ class UserModel {
     required this.email,
     this.profilFotoUrl,
         required this.favoriMekanlar, // CONSTRUCTOR'A EKLENDİ
+            this.yorumlar = const [], // Constructor'a ekle
   });
 
   // Backend'den gelen JSON verisinden model oluşturmak için
@@ -21,6 +25,19 @@ class UserModel {
       email: json['email'] ?? 'E-posta yok',
       profilFotoUrl: json['profilFotoUrl'], // YENİ
             favoriMekanlar: List<String>.from(json['favoriMekanlar'] ?? []),
+      yorumlar: const [],     );
+  }
+
+  // YENİ VE EKSİK OLAN METOT: Halka açık profil verisini parse eder
+  factory UserModel.fromPublicProfileJson(Map<String, dynamic> userJson, List<dynamic> yorumlarJson) {
+    return UserModel(
+      id: userJson['_id'],
+      kullaniciAdi: userJson['kullaniciAdi'],
+      profilFotoUrl: userJson['profilFotoUrl'],
+      // Halka açık profilde bu bilgiler olmadığı için varsayılan değerler atanır
+      email: '',
+      favoriMekanlar: [],
+      yorumlar: yorumlarJson.map((json) => YorumModel.fromJson(json)).toList(),
     );
   }
 

--- a/mobil_flutter/lib/data/services/api_service.dart
+++ b/mobil_flutter/lib/data/services/api_service.dart
@@ -3,6 +3,7 @@ import 'package:http/http.dart' as http;
 import 'package:mobil_flutter/data/models/mekan_model.dart';
 import 'package:mobil_flutter/data/models/yorum_model.dart';
 import 'package:mobil_flutter/data/services/auth_service.dart'; // Token almak için AuthService'e ihtiyacımız var
+import 'package:mobil_flutter/data/models/user_model.dart'; // UserModel'i kullanmak için gerekli
 
 class ApiService {
   final String _baseUrl = 'https://rize-kultur-api.onrender.com/api';
@@ -164,5 +165,28 @@ Future<List<MekanModel>> getMekanlarByIds(List<String> ids) async {
     } else {
       throw Exception('Favori mekanlar yüklenemedi.');
     }
+}
+
+
+// YENİ METOT
+Future<UserModel> getPublicUserProfile(String userId) async {
+  final url = '$_baseUrl/users/$userId';
+  final response = await http.get(Uri.parse(url));
+
+  if (response.statusCode == 200) {
+    // Backend'den gelen {kullanici: ..., yorumlar: ...} yapısını parse etmeliyiz.
+    // UserModel'e yorumları da ekleyebiliriz veya yeni bir model oluşturabiliriz.
+    // Şimdilik UserModel'i zenginleştirelim.
+    final responseJson = json.decode(utf8.decode(response.bodyBytes));
+    final userJson = responseJson['kullanici'];
+    final yorumlarJson = responseJson['yorumlar'] as List;
+
+    // UserModel.fromJson'ın bu yeni yapıyı handle edebilmesi lazım.
+    // Ya da burada manuel olarak birleştirme yapabiliriz.
+    // En temizi UserModel'e bir factory constructor daha eklemek.
+    return UserModel.fromPublicProfileJson(userJson, yorumlarJson);
+  } else {
+    throw Exception('Kullanıcı profili yüklenemedi. Hata Kodu: ${response.statusCode}');
+  }
 }
 }

--- a/mobil_flutter/lib/presentation/providers/user_providers.dart
+++ b/mobil_flutter/lib/presentation/providers/user_providers.dart
@@ -2,11 +2,12 @@
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mobil_flutter/data/models/user_model.dart';
-import 'package:mobil_flutter/data/services/auth_service.dart';
 import 'package:mobil_flutter/data/services/api_service.dart';
 import 'package:mobil_flutter/presentation/providers/mekan_providers.dart';
 import 'package:mobil_flutter/presentation/providers/auth_providers.dart';
 
+
+final apiServiceProvider = Provider((ref) => ApiService());
 
 // --- YENİ StateNotifier VE Provider ---
 // ESKİ FutureProvider'ın YERİNİ BU ALACAK
@@ -63,4 +64,13 @@ class UserProfileNotifier extends StateNotifier<AsyncValue<UserModel>> {
       state = currentState; 
     }
   }
+
 }
+
+// --- DÜZELTME BURADA ---
+// publicUserProfileProvider, UserProfileNotifier sınıfının DIŞINDA olmalı.
+final publicUserProfileProvider = FutureProvider.family<UserModel, String>((ref, userId) {
+  // ApiService provider'ını burada okuyup kullanıyoruz
+  final apiService = ref.watch(apiServiceProvider); 
+  return apiService.getPublicUserProfile(userId);
+});

--- a/mobil_flutter/lib/presentation/screens/main_navigation_screen.dart
+++ b/mobil_flutter/lib/presentation/screens/main_navigation_screen.dart
@@ -4,7 +4,7 @@ import 'package:mobil_flutter/presentation/providers/auth_providers.dart';
 import 'package:mobil_flutter/presentation/screens/ayarlar_ekrani_misafir.dart';
 import 'package:mobil_flutter/presentation/screens/harita_ekrani.dart';
 import 'package:mobil_flutter/presentation/screens/kesfet_ekrani.dart';
-import 'package:mobil_flutter/presentation/screens/profil/profil_ekrani.dart';
+import 'package:mobil_flutter/presentation/screens/profil/profil_sayfasi.dart';
 import 'package:mobil_flutter/presentation/screens/rotalar_ekrani.dart';
 import 'package:mobil_flutter/l10n/app_localizations.dart';
 
@@ -28,7 +28,7 @@ class MainNavigationScreen extends ConsumerWidget {
       const KesfetEkrani(),
       const HaritaEkrani(),
       const RotalarEkrani(),
-      isLoggedIn ? const ProfilEkrani() : const AyarlarEkraniMisafir(),
+      isLoggedIn ? const ProfilSayfasi() : const AyarlarEkraniMisafir(),
     ];
 
     return Scaffold(

--- a/mobil_flutter/lib/presentation/screens/profil/widgets/favoriler_tab.dart
+++ b/mobil_flutter/lib/presentation/screens/profil/widgets/favoriler_tab.dart
@@ -2,51 +2,50 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mobil_flutter/data/models/mekan_model.dart';
 import 'package:mobil_flutter/l10n/app_localizations.dart';
 import 'package:mobil_flutter/presentation/screens/mekan_detay_ekrani.dart';
 import 'package:mobil_flutter/presentation/widgets/mekan_karti.dart';
-import 'package:mobil_flutter/presentation/providers/mekan_providers.dart';
 
+// DÜZELTME: Bu widget da artık "aptal". Veriyi dışarıdan alıyor.
 class FavorilerTab extends ConsumerWidget {
-  const FavorilerTab({super.key}); // const constructor ekledik
+  final List<MekanModel> favoriMekanlar;
+  const FavorilerTab({super.key, required this.favoriMekanlar});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final favorilerAsync = ref.watch(favoriMekanlarProvider);
     final langCode = Localizations.localeOf(context).languageCode;
     final l10n = AppLocalizations.of(context)!;
 
-    return favorilerAsync.when(
-      loading: () => const Center(child: CircularProgressIndicator()),
-      error: (err, stack) => Center(child: Text('Favoriler yüklenemedi: $err')),
-      data: (mekanlar) => mekanlar.isEmpty
-          ? Center(child: Text(l10n.noFavoritesYet))
-          : GridView.builder(
-              padding: const EdgeInsets.all(16),
-              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                crossAxisCount: 2,
-                crossAxisSpacing: 16,
-                mainAxisSpacing: 16,
-                childAspectRatio: 0.8,
-              ),
-              itemCount: mekanlar.length,
-              itemBuilder: (context, index) {
-                final mekan = mekanlar[index];
-                return InkWell(
-                  onTap: () {
-                    Navigator.of(context).push(
-                      MaterialPageRoute(builder: (context) => MekanDetayEkrani(mekanId: mekan.id)),
-                    );
-                  },
-                  child: MekanKarti(
-                    isim: langCode == 'tr' ? mekan.isim.tr : mekan.isim.en,
-                    kategori: mekan.kategori,
-                    puan: mekan.ortalamaPuan,
-                    imageUrl: mekan.fotograflar.isNotEmpty ? mekan.fotograflar[0] : null,
-                  ),
-                );
-              },
-            ),
+    if (favoriMekanlar.isEmpty) {
+      return Center(child: Text(l10n.noFavoritesYet));
+    }
+
+    return GridView.builder(
+      padding: const EdgeInsets.all(16),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        crossAxisSpacing: 16,
+        mainAxisSpacing: 16,
+        childAspectRatio: 0.8,
+      ),
+      itemCount: favoriMekanlar.length,
+      itemBuilder: (context, index) {
+        final mekan = favoriMekanlar[index];
+        return InkWell(
+          onTap: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(builder: (context) => MekanDetayEkrani(mekanId: mekan.id)),
+            );
+          },
+          child: MekanKarti(
+            isim: langCode == 'tr' ? mekan.isim.tr : mekan.isim.en,
+            kategori: mekan.kategori,
+            puan: mekan.ortalamaPuan,
+            imageUrl: mekan.fotograflar.isNotEmpty ? mekan.fotograflar[0] : null,
+          ),
+        );
+      },
     );
   }
 }

--- a/mobil_flutter/lib/presentation/screens/profil/widgets/yorumlar_tab.dart
+++ b/mobil_flutter/lib/presentation/screens/profil/widgets/yorumlar_tab.dart
@@ -1,53 +1,90 @@
+// lib/presentation/screens/profil/widgets/yorumlar_tab.dart
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mobil_flutter/data/models/yorum_model.dart';
 import 'package:mobil_flutter/l10n/app_localizations.dart';
-import 'package:mobil_flutter/presentation/providers/mekan_providers.dart';
 import 'package:mobil_flutter/presentation/screens/mekan_detay_ekrani.dart';
+import 'package:mobil_flutter/presentation/widgets/puan_gostergesi.dart';
+import 'package:intl/intl.dart';
 
-
-
+// DÜZELTME: Bu widget artık "aptal". Veriyi dışarıdan parametre olarak alıyor.
 class YorumlarTab extends ConsumerWidget {
-  const YorumlarTab({super.key}); // const constructor ekledik
+  final List<YorumModel> yorumlar;
+  const YorumlarTab({super.key, required this.yorumlar});
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final yorumlarAsync = ref.watch(kullaniciYorumlariProvider);
-    final langCode = Localizations.localeOf(context).languageCode;
+    if (yorumlar.isEmpty) {
+      return Center(child: Text(AppLocalizations.of(context)!.noCommentsYet));
+    }
 
-    return yorumlarAsync.when(
-      loading: () => const Center(child: CircularProgressIndicator()),
-      error: (err, stack) => Center(child: Text('Yorumlar yüklenemedi: $err')),
-      data: (yorumlar) => yorumlar.isEmpty
-          ? Center(child: Text(AppLocalizations.of(context)!.noCommentsYet))
-          : ListView.builder(
-              padding: const EdgeInsets.all(16),
-              itemCount: yorumlar.length,
-              itemBuilder: (context, index) {
-                final yorum = yorumlar[index];
-                return Card(
-                  margin: const EdgeInsets.only(bottom: 12),
-                  child: ListTile(
-                    title: Text(
-                      langCode == 'tr' ? yorum.mekan?.isim.tr ?? 'Mekan Silinmiş' : yorum.mekan?.isim.en ?? 'Deleted Place',
-                    ),
-                    subtitle: Text(
-                      yorum.icerik ?? "(Sadece puan verildi)",
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    trailing: yorum.puan != null
-                        ? Text("★ ${yorum.puan!.toStringAsFixed(1)}", style: const TextStyle(fontSize: 16, color: Colors.amber))
-                        : null,
-                    onTap: () {
-                      if (yorum.mekan != null) {
-                        Navigator.of(context).push(
-                          MaterialPageRoute(builder: (context) => MekanDetayEkrani(mekanId: yorum.mekan!.id)),
-                        );
-                      }
-                    },
-                  ),
-                );
-              },
+    return ListView.separated(
+      padding: const EdgeInsets.all(16),
+      itemCount: yorumlar.length,
+      separatorBuilder: (context, index) => const SizedBox(height: 12),
+      itemBuilder: (context, index) {
+        final yorum = yorumlar[index];
+        return _ProfilYorumKarti(yorum: yorum);
+      },
+    );
+  }
+}
+
+class _ProfilYorumKarti extends StatelessWidget {
+  const _ProfilYorumKarti({required this.yorum});
+  final YorumModel yorum;
+
+  @override
+  Widget build(BuildContext context) {
+    final langCode = Localizations.localeOf(context).languageCode;
+    final theme = Theme.of(context);
+    final bool mekanMevcut = yorum.mekan != null;
+    final formattedDate = DateFormat.yMMMMd(langCode).format(yorum.yorumTarihi);
+
+    return Card(
+      color: mekanMevcut ? null : theme.disabledColor.withOpacity(0.1),
+      elevation: mekanMevcut ? 1 : 0,
+      child: ListTile(
+        leading: ClipRRect(
+          borderRadius: BorderRadius.circular(8.0),
+          child: AspectRatio(
+            aspectRatio: 1,
+            child: Image.network(
+              mekanMevcut && yorum.mekan!.fotograflar.isNotEmpty
+                  ? yorum.mekan!.fotograflar[0]
+                  : 'https://placehold.co/100x100/EEE/31343C?text=...',
+              fit: BoxFit.cover,
+              errorBuilder: (context, error, stackTrace) => const Icon(Icons.location_off),
             ),
+          ),
+        ),
+        title: Text(
+          langCode == 'tr' ? yorum.mekan?.isim.tr ?? 'Mekan Silinmiş' : yorum.mekan?.isim.en ?? 'Deleted Place',
+          style: TextStyle(fontWeight: FontWeight.bold, color: mekanMevcut ? null : theme.disabledColor),
+        ),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(yorum.icerik ?? "(Sadece puan verildi)", maxLines: 2, overflow: TextOverflow.ellipsis),
+            const SizedBox(height: 4),
+            Text(
+              formattedDate,
+              style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurface.withOpacity(0.6)),
+            ),
+          ],
+        ),
+        trailing: yorum.puan != null
+            ? Row(mainAxisSize: MainAxisSize.min, children: [
+                PuanGostergesi(puan: yorum.puan!, iconSize: 14),
+                const SizedBox(width: 4),
+                Text(yorum.puan!.toStringAsFixed(1), style: theme.textTheme.bodySmall),
+              ])
+            : null,
+        onTap: mekanMevcut
+            ? () => Navigator.of(context).push(MaterialPageRoute(builder: (context) => MekanDetayEkrani(mekanId: yorum.mekan!.id)))
+            : null,
+      ),
     );
   }
 }

--- a/mobil_flutter/lib/presentation/widgets/yorum_karti.dart
+++ b/mobil_flutter/lib/presentation/widgets/yorum_karti.dart
@@ -1,73 +1,91 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:mobil_flutter/data/models/yorum_model.dart';
+import 'package:mobil_flutter/presentation/screens/profil/profil_sayfasi.dart'; // DİKKAT: Yeni ProfilSayfasi'na import
 import 'package:mobil_flutter/presentation/widgets/puan_gostergesi.dart';
 
 class YorumKarti extends StatelessWidget {
-  final String kullaniciAdi;
-  final String? kullaniciImageUrl;
-  final double? puan;
-  final String? yorum;
-  final DateTime? yorumTarihi;
+  final YorumModel yorum;
 
   const YorumKarti({
     super.key,
-    required this.kullaniciAdi,
-    this.kullaniciImageUrl,
-    this.puan,
-    this.yorum,
-    this.yorumTarihi,
+    required this.yorum,
   });
 
   @override
   Widget build(BuildContext context) {
     final tema = Theme.of(context);
+    // DİL KODUNU BURADA ALALIM
+    final langCode = Localizations.localeOf(context).languageCode;
 
     return Container(
       padding: const EdgeInsets.all(16.0),
       decoration: BoxDecoration(
-        color: tema.colorScheme.surface,
-        borderRadius: BorderRadius.circular(12.0),
-        border: Border.all(color: tema.dividerColor.withOpacity(0.1))
-      ),
+          color: tema.colorScheme.surface,
+          borderRadius: BorderRadius.circular(12.0),
+          border: Border.all(color: tema.dividerColor.withOpacity(0.1))),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(
-            children: [
-              CircleAvatar(
-                backgroundImage: (kullaniciImageUrl != null && kullaniciImageUrl!.isNotEmpty)
-                    ? NetworkImage(kullaniciImageUrl!)
-                    : null,
-                child: (kullaniciImageUrl == null || kullaniciImageUrl!.isEmpty)
-                    ? const Icon(Icons.person)
-                    : null,
-              ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      kullaniciAdi,
-                      style: tema.textTheme.titleMedium,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    if (yorumTarihi != null)
-                      Text(
-                        DateFormat.yMMMMd('tr_TR').format(yorumTarihi!),
-                        style: tema.textTheme.bodySmall,
-                      ),
-                  ],
+          // YENİ: Yazar bilgisi alanını tıklanabilir yapmak için InkWell
+          InkWell(
+            onTap: () {
+              // Tıklandığında yazarın profil sayfasına git
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => ProfilSayfasi(userId: yorum.yazar.id),
                 ),
+              );
+            },
+            borderRadius: BorderRadius.circular(8), // Tıklama efektinin şekli
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4.0),
+              child: Row(
+                children: [
+                  // DÜZELTME: Profil fotoğrafını yorum.yazar'dan al
+                  CircleAvatar(
+                    backgroundImage: (yorum.yazar.profilFotoUrl != null &&
+                            yorum.yazar.profilFotoUrl!.isNotEmpty)
+                        ? NetworkImage(yorum.yazar.profilFotoUrl!)
+                        : null,
+                    child: (yorum.yazar.profilFotoUrl == null ||
+                            yorum.yazar.profilFotoUrl!.isEmpty)
+                        ? const Icon(Icons.person)
+                        : null,
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        // DÜZELTME: Kullanıcı adını yorum.yazar'dan al
+                        Text(
+                          yorum.yazar.kullaniciAdi,
+                          style: tema.textTheme.titleMedium,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        // DÜZELTME: Tarihi yorum'dan al ve formatla
+                        Text(
+                          DateFormat.yMMMMd(langCode)
+                              .format(yorum.yorumTarihi),
+                          style: tema.textTheme.bodySmall,
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  // DÜZELTME: Puanı yorum'dan al
+                  if (yorum.puan != null)
+                    PuanGostergesi(puan: yorum.puan!, iconSize: 16),
+                ],
               ),
-              const SizedBox(width: 12),
-              if (puan != null) PuanGostergesi(puan: puan!, iconSize: 16),
-            ],
+            ),
           ),
-          if (yorum != null && yorum!.trim().isNotEmpty) ...[
+          // DÜZELTME: Yorum içeriğini yorum.icerik'ten al
+          if (yorum.icerik != null && yorum.icerik!.trim().isNotEmpty) ...[
             const SizedBox(height: 12),
             Text(
-              yorum!,
+              yorum.icerik!,
               style: tema.textTheme.bodyLarge,
             ),
           ],

--- a/mobil_flutter/lib/presentation/widgets/yorumlar_sayfasi.dart
+++ b/mobil_flutter/lib/presentation/widgets/yorumlar_sayfasi.dart
@@ -76,11 +76,7 @@ class _YorumlarSayfasiState extends ConsumerState<YorumlarSayfasi> {
                       return Padding(
                         padding: const EdgeInsets.only(bottom: 16.0),
                         child: YorumKarti(
-                          kullaniciAdi: yorum.yazar.kullaniciAdi,
-                          puan: yorum.puan,
-                          yorum: yorum.icerik,
-                          kullaniciImageUrl: yorum.yazar.profilFotoUrl,
-                          yorumTarihi: yorum.yorumTarihi,
+                          yorum: yorum,
                         ),
                       );
                     },
@@ -146,11 +142,7 @@ class _KullaniciYorumuGoster extends StatelessWidget {
           ),
           const SizedBox(height: 8),
           YorumKarti(
-            kullaniciAdi: yorum.yazar.kullaniciAdi,
-            puan: yorum.puan,
-            yorum: yorum.icerik,
-            kullaniciImageUrl: yorum.yazar.profilFotoUrl,
-            yorumTarihi: yorum.yorumTarihi,
+            yorum: yorum
           ),
         ],
       ),


### PR DESCRIPTION
Bu commit, kullanıcı profili sistemini baştan sona yeniler. Artık kullanıcılar hem kendi profillerini düzenleyebilir hem de diğer kullanıcıların halka açık profillerini görüntüleyebilir.

Özellikler:
- **Halka Açık Profiller:** Yorum kartlarındaki kullanıcılara tıklandığında, o kullanıcıya ait yorumları gösteren dinamik bir profil sayfası açılır.
- **Profil Düzenleme:** Kullanıcılar artık kullanıcı adlarını, profil fotoğraflarını ve şifrelerini güncelleyebilir. 'Profili Düzenle' ekranı eklendi.
- **İyimser Güncellemeler (Optimistic Updates):** Favoriye ekleme/çıkarma işlemi, sunucu yanıtı beklenmeden arayüzde anında yansıtılır, bu da kullanıcı deneyimini iyileştirir.

Yeniden Düzenleme (Refactoring):
- **State Management:** `userProfileProvider`, anlık güncellemeleri (favori gibi) daha iyi yönetmek için `FutureProvider`'dan `StateNotifierProvider`'a geçirildi.
- **Dinamik `ProfilSayfasi`:** `ProfilEkrani`, artık bir `userId` alabilen ve hem kendi profilini hem de başkalarının profilini gösterebilen `ProfilSayfasi`'na dönüştürüldü.
- **Bileşen Yapısı:** Profil sayfasının tab'ları (`YorumlarTab`, `FavorilerTab`) veriyi parametre olarak alan "aptal" bileşenlere dönüştürüldü. Bu, kodun yeniden kullanılabilirliğini ve test edilebilirliğini artırır.

Backend:
- Kullanıcıların halka açık verilerini ve yorumlarını getirmek için yeni bir API uç noktası (`GET /api/users/:userId`) eklendi.
- Yorum rotalarındaki yazar bilgisi, profil fotoğrafını da içerecek şekilde zenginleştirildi.